### PR TITLE
Mirror of facebook litho PR IssueNumber 762

### DIFF
--- a/litho-it/src/test/java/com/facebook/litho/AttachDetachHandlerTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/AttachDetachHandlerTest.java
@@ -31,7 +31,9 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class AttachDetachHandlerTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/CollectTransitionsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/CollectTransitionsTest.java
@@ -28,7 +28,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class CollectTransitionsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/CommonPropsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/CommonPropsTest.java
@@ -51,7 +51,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class CommonPropsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ComponentGlobalKeyTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentGlobalKeyTest.java
@@ -41,7 +41,9 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentGlobalKeyTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ComponentPropThreadSafetyTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentPropThreadSafetyTest.java
@@ -36,8 +36,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentPropThreadSafetyTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ComponentTreeHasCompatibleLayoutTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentTreeHasCompatibleLayoutTest.java
@@ -30,8 +30,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentTreeHasCompatibleLayoutTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ComponentTreeMountTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentTreeMountTest.java
@@ -36,7 +36,9 @@ import com.facebook.litho.widget.Text;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentTreeMountTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ComponentTreeNewLayoutStateReadyListenerTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentTreeNewLayoutStateReadyListenerTest.java
@@ -34,8 +34,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentTreeNewLayoutStateReadyListenerTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ComponentTreeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ComponentTreeTest.java
@@ -61,8 +61,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentTreeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/DeprecatedLithoTooltipTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/DeprecatedLithoTooltipTest.java
@@ -31,7 +31,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class DeprecatedLithoTooltipTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/DynamicPropsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/DynamicPropsTest.java
@@ -35,7 +35,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class DynamicPropsTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/InternalNodeResolvedPaddingTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/InternalNodeResolvedPaddingTest.java
@@ -33,7 +33,9 @@ import com.facebook.yoga.YogaDirection;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class InternalNodeResolvedPaddingTest {
   private InternalNode mInternalNode;

--- a/litho-it/src/test/java/com/facebook/litho/InternalNodeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/InternalNodeTest.java
@@ -56,7 +56,9 @@ import com.facebook.yoga.YogaNode;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class InternalNodeTest {
   private static final int LIFECYCLE_TEST_ID = 1;

--- a/litho-it/src/test/java/com/facebook/litho/InternalNodeTouchExpansionTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/InternalNodeTouchExpansionTest.java
@@ -34,7 +34,9 @@ import com.facebook.yoga.YogaDirection;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class InternalNodeTouchExpansionTest {
   private InternalNode mInternalNode;

--- a/litho-it/src/test/java/com/facebook/litho/LayoutStateAddChildWithInputTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LayoutStateAddChildWithInputTest.java
@@ -24,7 +24,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LayoutStateAddChildWithInputTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/LayoutStateCalculateTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LayoutStateCalculateTest.java
@@ -80,8 +80,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowAccessibilityManager;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LayoutStateCalculateTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/LayoutStateCalculateTopsAndBottomsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LayoutStateCalculateTopsAndBottomsTest.java
@@ -41,7 +41,9 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LayoutStateCalculateTopsAndBottomsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/LayoutStateCalculateVisibilityOutputsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LayoutStateCalculateVisibilityOutputsTest.java
@@ -32,7 +32,9 @@ import com.facebook.litho.widget.SimpleMountSpecTester;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LayoutStateCalculateVisibilityOutputsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/LayoutStateCreateTreeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LayoutStateCreateTreeTest.java
@@ -47,7 +47,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LayoutStateCreateTreeTest {
   private ComponentContext mComponentContext;

--- a/litho-it/src/test/java/com/facebook/litho/LayoutStateEventHandlerTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LayoutStateEventHandlerTest.java
@@ -25,7 +25,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LayoutStateEventHandlerTest {
   private int mUnspecifiedSizeSpec = 0; // SizeSpec.makeSizeSpec(0, SizeSpec.UNSPECIFIED);

--- a/litho-it/src/test/java/com/facebook/litho/LayoutStateFutureReleaseTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LayoutStateFutureReleaseTest.java
@@ -39,8 +39,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LayoutStateFutureReleaseTest {
   private int mWidthSpec;

--- a/litho-it/src/test/java/com/facebook/litho/LithoViewMountTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/LithoViewMountTest.java
@@ -35,11 +35,13 @@ import com.facebook.litho.widget.SimpleMountSpecTester;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /**
  * Tests for {@link LithoView} and {@link MountState} to make sure mount only happens once when
  * attaching the view and setting the component.
  */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class LithoViewMountTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/MountStateBetterLoggingTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateBetterLoggingTest.java
@@ -33,8 +33,10 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests that Mount events are only logged when tracing is enabled. */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateBetterLoggingTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/MountStateBoundsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateBoundsTest.java
@@ -32,7 +32,9 @@ import com.facebook.yoga.YogaJustify;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateBoundsTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/MountStateFocusableTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateFocusableTest.java
@@ -28,7 +28,9 @@ import com.facebook.litho.widget.SimpleMountSpecTester;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateFocusableTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/MountStateLoggingTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateLoggingTest.java
@@ -38,8 +38,10 @@ import java.util.function.Predicate;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests that Mount events are only logged when tracing is enabled. */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateLoggingTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/MountStateRemountEventHandlerTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateRemountEventHandlerTest.java
@@ -31,7 +31,9 @@ import com.facebook.litho.widget.SimpleMountSpecTester;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateRemountEventHandlerTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/MountStateRemountInPlaceTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateRemountInPlaceTest.java
@@ -48,7 +48,9 @@ import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateRemountInPlaceTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/MountStateRemountTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateRemountTest.java
@@ -43,7 +43,9 @@ import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateRemountTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/MountStateTestItemTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateTestItemTest.java
@@ -32,7 +32,9 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateTestItemTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/MountStateViewClickTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateViewClickTest.java
@@ -28,7 +28,9 @@ import com.facebook.litho.widget.SimpleMountSpecTester;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateViewClickTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/MountStateViewTagsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateViewTagsTest.java
@@ -29,7 +29,9 @@ import com.facebook.litho.widget.SimpleMountSpecTester;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateViewTagsTest {
   private static final int DUMMY_ID = 0x10000000;

--- a/litho-it/src/test/java/com/facebook/litho/MountStateViewTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/MountStateViewTest.java
@@ -52,7 +52,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class MountStateViewTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/NestedComponentStateUpdatesWithReconciliationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/NestedComponentStateUpdatesWithReconciliationTest.java
@@ -39,8 +39,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class NestedComponentStateUpdatesWithReconciliationTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ResolveAttributeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ResolveAttributeTest.java
@@ -37,7 +37,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ResolveAttributeTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/ResolveResTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ResolveResTest.java
@@ -28,7 +28,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ResolveResTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/StateUpdatesTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/StateUpdatesTest.java
@@ -40,8 +40,10 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class StateUpdatesTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/StateUpdatesWithReconciliationTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/StateUpdatesWithReconciliationTest.java
@@ -51,8 +51,10 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class StateUpdatesWithReconciliationTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/TreeDiffingTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/TreeDiffingTest.java
@@ -61,7 +61,9 @@ import java.util.HashMap;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class TreeDiffingTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/UniqueTransitionKeysTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/UniqueTransitionKeysTest.java
@@ -26,7 +26,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class UniqueTransitionKeysTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ViewCompatComponentTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ViewCompatComponentTest.java
@@ -32,8 +32,10 @@ import com.facebook.litho.viewcompat.ViewCreator;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ViewCompatComponent} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ViewCompatComponentTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/ViewNodeInfoTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/ViewNodeInfoTest.java
@@ -24,8 +24,10 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ViewNodeInfo} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ViewNodeInfoTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/VisibilityEventsTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/VisibilityEventsTest.java
@@ -50,7 +50,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.ParameterizedRobolectricTestRunner;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(ParameterizedRobolectricTestRunner.class)
 public class VisibilityEventsTest {
   private static final int LEFT = 0;

--- a/litho-it/src/test/java/com/facebook/litho/WillRenderTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/WillRenderTest.java
@@ -28,7 +28,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class WillRenderTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/YogaAlignBaselineTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/YogaAlignBaselineTest.java
@@ -27,7 +27,9 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class YogaAlignBaselineTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/widget/ComponentTreeHolderTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/ComponentTreeHolderTest.java
@@ -38,9 +38,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
 /** Tests for {@link ComponentTreeHolder} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ComponentTreeHolderTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/widget/EditTextSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/EditTextSpecTest.java
@@ -26,8 +26,10 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link EditText} component. */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class EditTextSpecTest {
   @Rule public ComponentsRule mComponentsRule = new ComponentsRule();

--- a/litho-it/src/test/java/com/facebook/litho/widget/ProgressSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/ProgressSpecTest.java
@@ -27,8 +27,10 @@ import com.facebook.litho.testing.testrunner.LithoTestRunner;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link ProgressSpec} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class ProgressSpecTest {
   private ComponentContext mContext;

--- a/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderManualRangeTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderManualRangeTest.java
@@ -42,9 +42,11 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
 /** Tests for manually specifying estimatedViewportCount to {@link RecyclerBinder} */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class RecyclerBinderManualRangeTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderWrapContentTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/RecyclerBinderWrapContentTest.java
@@ -46,9 +46,11 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Shadows;
+import org.robolectric.annotation.LooperMode;
 import org.robolectric.shadows.ShadowLooper;
 
 /** Tests for {@link RecyclerBinder} with wrap content enabled. */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class RecyclerBinderWrapContentTest {
 

--- a/litho-it/src/test/java/com/facebook/litho/widget/TextInputSpecTest.java
+++ b/litho-it/src/test/java/com/facebook/litho/widget/TextInputSpecTest.java
@@ -44,8 +44,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.annotation.LooperMode;
 
 /** Tests {@link TextInput} component. */
+@LooperMode(LooperMode.Mode.LEGACY)
 @RunWith(LithoTestRunner.class)
 public class TextInputSpecTest {
   private ComponentContext mContext;


### PR DESCRIPTION
Mirror of facebook litho PR IssueNumber 762
 Summary

The new Robolectric PAUSED LooperMode will become the default in new versions of
Robolectric. We have ran all litho-it tests against the new PAUSED LooperMode and
unfortunately some of them are failing. For these tests we need to explicitly specify the
LooperMode as LEGACY to be future proof, so that they do not start failing when the
default changes to PAUSED in the future.

 Changelog

Add <at>LooperMode LEGACY in tests that fail in PAUSED LooperMode

 Test Plan

N/A, this change only affects tests

